### PR TITLE
Add initial sqlite3 support.

### DIFF
--- a/example/config_tutorial.py
+++ b/example/config_tutorial.py
@@ -5,6 +5,24 @@ DATABASES = {
             'dsn': 'host=127.0.0.1 dbname=mtutorial',
         },
 
+        'sqlite3': {
+            'migrations_dir': './migrations/',
+            'engine': 'sqlite3',
+            # First "database" argument to sqlite3.connect()
+            'database': './dbname.sq3',
+        },
+
+        'sqlite3-readonly': {
+            'migrations_dir': './migrations/',
+            'engine': 'sqlite3',
+            'database': 'file:./dbname.sq3?mode=ro',
+            'connect_kwargs': {
+                # Named "uri" argument to sqlite3.connect(), changes how
+                # database argument is interpreted.
+                'uri': True,
+            },
+        },
+
         'other': {
             'migrations_dir': './migrations_other/',
             'engine': 'postgres',

--- a/mschematool/core.py
+++ b/mschematool/core.py
@@ -241,6 +241,7 @@ class MigrationsExecutor(object):
 ENGINE_TO_IMPL = {
     'postgres': 'mschematool.executors.postgres.PostgresMigrations',
     'cassandra': 'mschematool.executors.cassandradb.CassandraMigrations',
+    'sqlite3': 'mschematool.executors.sqlite3.Sqlite3Migrations',
 }
 
 

--- a/mschematool/executors/postgres.py
+++ b/mschematool/executors/postgres.py
@@ -31,7 +31,7 @@ class PostgresLoggingDictCursor(psycopg2.extras.DictCursor):
 class PostgresMigrations(core.MigrationsExecutor):
 
     engine = 'postgres'
-    patterns = ['m*.sql', 'm*.py']
+    patterns = ['m*.sql', 'm*.psql', 'm*.py']
 
     TABLE = 'migration'
 

--- a/mschematool/executors/sqlite3.py
+++ b/mschematool/executors/sqlite3.py
@@ -1,0 +1,83 @@
+import logging
+import os
+
+import sqlite3
+
+from mschematool import core
+
+
+log = core.log
+
+
+class Sqlite3LoggingCursor(sqlite3.Cursor):
+    """SQLite3 cursor subclass: log all SQL executed in the database.
+    """
+
+    def __init__(self, *args, **kwargs):
+        sqlite3.Cursor.__init__(self, *args, **kwargs)
+
+    def execute(self, sql, *args):
+        if log.isEnabledFor(logging.INFO):
+            log.info('Executing SQL: <<%s>> with args: <<%s>>', sql, args)
+        try:
+            sqlite3.Cursor.execute(self, sql, *args)
+        except:
+            log.exception('Exception while executing SQL')
+            raise
+
+
+class Sqlite3Migrations(core.MigrationsExecutor):
+
+    engine = 'sqlite3'
+    patterns = ['m*.sql', 'm*.sql3', 'm*.py']
+
+    TABLE = 'migration'
+
+    def __init__(self, db_config, repository):
+        core.MigrationsExecutor.__init__(self, db_config, repository)
+        self.conn = sqlite3.connect(self.db_config['database'], **db_config.get('connect_kwargs', {}))
+        # Ensure we return dict/tuple-based access instead of just tuples
+        self.conn.row_factory = sqlite3.Row
+
+    def cursor(self):
+        return self.conn.cursor(Sqlite3LoggingCursor)
+
+    def initialize(self):
+        cur = self.cursor()
+        cur.execute("""SELECT EXISTS(SELECT * FROM sqlite_master
+                       WHERE tbl_name=?)""", (self.TABLE,))
+        already_exists = cur.fetchone()[0]
+        if not already_exists:
+            cur.execute("""CREATE TABLE {table} (
+                file TEXT,
+                executed TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )""".format(table=self.TABLE))
+            cur.connection.commit()
+
+    def fetch_executed_migrations(self):
+        cur = self.cursor()
+        cur.execute("""SELECT file FROM {table}
+                       ORDER BY executed""".format(table=self.TABLE))
+        return [row[0] for row in cur.fetchall()]
+
+    def _migration_success(self, migration_file):
+        migration = os.path.split(migration_file)[1]
+        self.cursor().execute("""INSERT INTO {table} (file) VALUES (?)""".format(table=self.TABLE),
+                              (migration,))
+
+    def execute_python_migration(self, migration_file, module):
+        assert hasattr(module, 'migrate'), 'Python module must have `migrate` function accepting ' \
+            'a database connection'
+        module.migrate(self.conn)
+        self._migration_success(migration_file)
+        self.conn.commit()
+
+    def execute_native_migration(self, migration_file):
+        with open(migration_file) as f:
+            content = f.read()
+        for statement in core._sqlfile_to_statements(content):
+            self.cursor().execute(statement)
+        self._migration_success(migration_file)
+        self.conn.commit()
+
+

--- a/tests/config_basic.py
+++ b/tests/config_basic.py
@@ -26,6 +26,14 @@ DATABASES = {
                 'contact_points': ['127.0.0.1'],
                 'port': 9042,
             },
+        },
+
+        'sqlite3_default': {
+            'migrations_dir': os.path.join(BASE_DIR, 'migrations1'),
+            'engine': 'sqlite3',
+            'database': '/tmp/sqlite3test.sql',
+            'connect_kwargs': {
+            },
         }
 }
 


### PR DESCRIPTION
Since sqlite3 support comes shipped with Python, there are no additional
dependencies, so this should work easily out of the box.
