### PR TITLE
Makes mschematool work with multiple postgres schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ DATABASES = {
             'engine': 'postgres',
             'dsn': 'host=127.0.0.1 dbname=mother',
             'after_sync': 'pg_dump -s mother > /tmp/mother_schema.sql',
-            'migrations_table': 'mother_migrations',
+            'migration_table': 'mother_migrations',
         },
 }
 
@@ -62,7 +62,7 @@ For each "dbnick" (a short database name - `default` and `other` in the example)
 ## PostgreSQL specific options
 
 * `dsn` specifies database connection parameters for the `postgres` engine, as described here: http://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
-* `migrations_table` optionally specifies the name of the table that keeps track of which migrations are already applied. The default is `"public.migration"`.
+* `migration_table` optionally specifies the name of the table that keeps track of which migrations are already applied. The default is `"public.migration"`.
 
 ## Sqlite3 specific options
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ DATABASES = {
             'engine': 'postgres',
             'dsn': 'host=127.0.0.1 dbname=mother',
             'after_sync': 'pg_dump -s mother > /tmp/mother_schema.sql',
+            'migrations_table': 'mother_migrations',
         },
 }
 
@@ -61,6 +62,7 @@ For each "dbnick" (a short database name - `default` and `other` in the example)
 ## PostgreSQL specific options
 
 * `dsn` specifies database connection parameters for the `postgres` engine, as described here: http://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
+* `migrations_table` optionally specifies the name of the table that keeps track of which migrations are already applied. The default is `"public.migration"`.
 
 ## Sqlite3 specific options
 

--- a/mschematool/executors/postgres.py
+++ b/mschematool/executors/postgres.py
@@ -33,11 +33,10 @@ class PostgresMigrations(core.MigrationsExecutor):
     engine = 'postgres'
     filename_extensions = ['sql']
 
-    TABLE = 'migration'
-
     def __init__(self, db_config, repository):
         core.MigrationsExecutor.__init__(self, db_config, repository)
         self.conn = psycopg2.connect(self.db_config['dsn'])
+        self.migration_table_name = self.db_config.get('migration_table_name', 'public.migration')
 
     def cursor(self):
         return self.conn.cursor(cursor_factory=PostgresLoggingDictCursor)
@@ -47,19 +46,19 @@ class PostgresMigrations(core.MigrationsExecutor):
             cur.execute("""CREATE TABLE IF NOT EXISTS {table} (
                 file TEXT,
                 executed TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-            )""".format(table=self.TABLE))
+            )""".format(table=self.migration_table_name))
             cur.connection.commit()
 
     def fetch_executed_migrations(self):
         with self.cursor() as cur:
             cur.execute("""SELECT file FROM {table}
-            ORDER BY executed""".format(table=self.TABLE))
+            ORDER BY executed""".format(table=self.migration_table_name))
             return [row[0] for row in cur.fetchall()]
 
     def _migration_success(self, migration_file):
         migration = os.path.split(migration_file)[1]
         with self.cursor() as cur:
-            cur.execute("""INSERT INTO {table} (file) VALUES (%s)""".format(table=self.TABLE),
+            cur.execute("""INSERT INTO {table} (file) VALUES (%s)""".format(table=self.migration_table_name),
                     [migration])
 
     def execute_python_migration(self, migration_file, module):

--- a/mschematool/executors/postgres.py
+++ b/mschematool/executors/postgres.py
@@ -38,6 +38,12 @@ class PostgresMigrations(core.MigrationsExecutor):
         self.conn = psycopg2.connect(self.db_config['dsn'])
         self.migration_table = self.db_config.get('migration_table', 'public.migration')
 
+        if '.' not in self.migration_table:
+            msg = "Migration table name '%s' must include schema" % self.migration_table
+            sys.stderr.write(msg + '\n')
+            log.critical(msg)
+            raise Exception(msg)
+
     def cursor(self):
         return self.conn.cursor(cursor_factory=PostgresLoggingDictCursor)
 

--- a/mschematool/executors/postgres.py
+++ b/mschematool/executors/postgres.py
@@ -44,13 +44,7 @@ class PostgresMigrations(core.MigrationsExecutor):
 
     def initialize(self):
         with self.cursor() as cur:
-            cur.execute("""SELECT EXISTS(SELECT * FROM information_schema.tables
-                           WHERE table_name=%s)""", [self.TABLE])
-            already_exists = cur.fetchone()[0]
-        if already_exists:
-            return
-        with self.cursor() as cur:
-            cur.execute("""CREATE TABLE {table} (
+            cur.execute("""CREATE TABLE IF NOT EXISTS {table} (
                 file TEXT,
                 executed TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )""".format(table=self.TABLE))

--- a/tests/config_basic.py
+++ b/tests/config_basic.py
@@ -28,6 +28,13 @@ DATABASES = {
             'dsn': 'host=127.0.0.1 dbname=mtest1',
         },
 
+        'different_schema': {
+            'migrations_dir': os.path.join(BASE_DIR, 'different_schema'),
+            'engine': 'postgres',
+            'dsn': 'host=127.0.0.1 dbname=mtest1',
+            'migration_table': 'hooli.migration'
+        },
+
         'cass_default': {
             'migrations_dir': os.path.join(BASE_DIR, 'cass1'),
             'engine': 'cassandra',

--- a/tests/different_schema/001_chat.sql
+++ b/tests/different_schema/001_chat.sql
@@ -1,0 +1,1 @@
+CREATE TABLE hooli.messages (senderId int, recipientId int, body text);

--- a/tests/different_schema/002_mail.sql
+++ b/tests/different_schema/002_mail.sql
@@ -1,0 +1,1 @@
+CREATE TABLE hooli.mail (sender text, recipient text, subject text, body text);

--- a/tests/different_schema/003_search.sql
+++ b/tests/different_schema/003_search.sql
@@ -1,0 +1,1 @@
+CREATE TABLE hooli.searchIndex (token text, position int, docid int);

--- a/tests/different_schema/004_phone.sql
+++ b/tests/different_schema/004_phone.sql
@@ -1,0 +1,1 @@
+CREATE TABLE hooli.phones (phoneNumber int, modelVersion int);

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -253,6 +253,19 @@ class PostgresTestPassingDbConfig(PostgresTestBase):
         self.assertEqual([1, 2, 3], ids)
 
 
+class PostgresTestDifferentSchema(PostgresTestBase):
+    dbnick = 'different_schema'
+
+    def testSync(self):
+        with self.r.cursor() as cur:
+            cur.execute("""CREATE SCHEMA hooli""")
+            cur.execute("""COMMIT""")
+        self.r.run('init_db')
+        self.r.run('sync')
+        out = self.r.run('latest_synced')
+        assert out.endswith('004_phone.sql')
+
+
 ### Cassandra tests
 
 


### PR DESCRIPTION
There is a problem when you are using multiple postgres schemas (should be called namespace in this usage), and you want to run `mschematool` on more than one of them.

For example, I have a database with two schemas, `public`, and `dirkgr`. I want to run `mschematool` on both. The first time I run it on the `public` schema, and everything is fine. The second time, I try to run it on the `dirkgr` schema, and I find that `init_db` does nothing. The problem is that `SELECT * FROM information_schema.tables WHERE table_name=%s` will find the `migrations` table in any of the schemas that are present in the DB, and abort.